### PR TITLE
Add support for scaling mesh x,y,z independently

### DIFF
--- a/src/pytorch_volumetric/model_to_sdf.py
+++ b/src/pytorch_volumetric/model_to_sdf.py
@@ -45,7 +45,9 @@ class RobotSDF(sdf.ObjectFrameSDF):
             for link_vis in frame.link.visuals:
                 if link_vis.geom_type == "mesh":
                     logger.info(f"{frame.link.name} offset {link_vis.offset}")
-                    link_obj = sdf.MeshObjectFactory(link_vis.geom_param, path_prefix=path_prefix)
+                    link_obj = sdf.MeshObjectFactory(link_vis.geom_param[0],
+                                                     scale=link_vis.geom_param[1],
+                                                     path_prefix=path_prefix)
                     link_sdf = link_sdf_cls(link_obj)
                     self.sdf_to_link_name.append(frame.link.name)
                     sdfs.append(link_sdf)

--- a/src/pytorch_volumetric/sdf.py
+++ b/src/pytorch_volumetric/sdf.py
@@ -29,7 +29,7 @@ class ObjectFactory(abc.ABC):
     def __init__(self, name, scale=1.0, vis_frame_pos=(0, 0, 0), vis_frame_rot=(0, 0, 0, 1),
                  plausible_suboptimality=0.001, **kwargs):
         self.name = name
-        self.scale = scale
+        self.scale = scale if scale is not None else 1.0
         # frame from model's base frame to the simulation's use of the model
         self.vis_frame_pos = vis_frame_pos
         self.vis_frame_rot = vis_frame_rot
@@ -77,7 +77,11 @@ class ObjectFactory(abc.ABC):
         full_path = self.get_mesh_high_poly_resource_filename()
         if not os.path.exists(full_path):
             raise RuntimeError(f"Expected mesh file does not exist: {full_path}")
-        self._mesh = o3d.io.read_triangle_mesh(full_path).scale(self.scale, [0, 0, 0])
+        self._mesh = o3d.io.read_triangle_mesh(full_path)
+        # scale mesh
+        scale_transform = np.eye(4)
+        np.fill_diagonal(scale_transform[:3, :3], self.scale)
+        self._mesh.transform(scale_transform)
         # convert from mesh object frame to simulator object frame
         x, y, z, w = self.vis_frame_rot
         self._mesh = self._mesh.rotate(o3d.geometry.get_rotation_matrix_from_quaternion((w, x, y, z)),


### PR DESCRIPTION
Adds support for scaling mesh by x,y,z independently. In RobotSDF, reads scale parameter from urdf.