### PR TITLE
Robot sdf batching fix

### DIFF
--- a/src/pytorch_volumetric/model_to_sdf.py
+++ b/src/pytorch_volumetric/model_to_sdf.py
@@ -105,6 +105,9 @@ class RobotSDF(sdf.ObjectFrameSDF):
         if self.configuration_batch is not None:
             offset_tsf = pk.Transform3d(matrix=offset_tsf.get_matrix().repeat(*self.configuration_batch, 1, 1))
         self.object_to_link_frames = offset_tsf.compose(pk.Transform3d(matrix=torch.cat(tsfs).inverse()))
+
+        tsfs = torch.stack(tsfs, dim=1).reshape(-1, 4, 4)
+        self.object_to_link_frames = offset_tsf.compose(pk.Transform3d(matrix=tsfs.inverse()))
         if self.sdf is not None:
             self.sdf.set_transforms(self.object_to_link_frames, batch_dim=self.configuration_batch)
 

--- a/src/pytorch_volumetric/model_to_sdf.py
+++ b/src/pytorch_volumetric/model_to_sdf.py
@@ -104,7 +104,6 @@ class RobotSDF(sdf.ObjectFrameSDF):
         offset_tsf = self.offset_transforms.inverse()
         if self.configuration_batch is not None:
             offset_tsf = pk.Transform3d(matrix=offset_tsf.get_matrix().repeat(*self.configuration_batch, 1, 1))
-        self.object_to_link_frames = offset_tsf.compose(pk.Transform3d(matrix=torch.cat(tsfs).inverse()))
 
         tsfs = torch.stack(tsfs, dim=1).reshape(-1, 4, 4)
         self.object_to_link_frames = offset_tsf.compose(pk.Transform3d(matrix=tsfs.inverse()))


### PR DESCRIPTION
`pytorch_kinematics.Transform3d` can only have a single batch dimension.  

In `RobotSDF`, `offset_tsf` was (batch, num_links), whereas `tsfs` was (num_links, batch). Both are then flattened to a single batch dimension batch*num_links. This results in incorrect behaviour. 

This fix makes both (batch, num_links)
